### PR TITLE
[Feature] 좋아요 기능 구현

### DIFF
--- a/be/tcono/build.gradle
+++ b/be/tcono/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
 
     /* mockito 관련 */
-    testImplementation "org.mockito:mockito-core:3.3.3"
+    testImplementation 'org.mockito:mockito-junit-jupiter:3.11.2'
 
     /* querydsl 관련 */
     implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"

--- a/be/tcono/src/main/java/com/econo/tcono/domain/like/domain/Like.java
+++ b/be/tcono/src/main/java/com/econo/tcono/domain/like/domain/Like.java
@@ -1,4 +1,6 @@
-package com.econo.tcono.domain.like;
+package com.econo.tcono.domain.like.domain;
+
+import lombok.Builder;
 
 import javax.persistence.*;
 
@@ -15,4 +17,13 @@ public class Like {
 
     @Column(name = "idp_id")
     private Long idpId;
+
+    @Builder
+    public Like(Long postId, Long idpId) {
+        this.postId = postId;
+        this.idpId = idpId;
+    }
+
+    protected Like() {
+    }
 }

--- a/be/tcono/src/main/java/com/econo/tcono/domain/like/repository/LikeCustomRepository.java
+++ b/be/tcono/src/main/java/com/econo/tcono/domain/like/repository/LikeCustomRepository.java
@@ -1,0 +1,5 @@
+package com.econo.tcono.domain.like.repository;
+
+public interface LikeCustomRepository {
+    void deleteByPostIdAndIdpId(Long postId, Long idpId);
+}

--- a/be/tcono/src/main/java/com/econo/tcono/domain/like/repository/LikeCustomRepository.java
+++ b/be/tcono/src/main/java/com/econo/tcono/domain/like/repository/LikeCustomRepository.java
@@ -2,4 +2,5 @@ package com.econo.tcono.domain.like.repository;
 
 public interface LikeCustomRepository {
     void deleteByPostIdAndIdpId(Long postId, Long idpId);
+    void deleteAllByPostId(Long postId);
 }

--- a/be/tcono/src/main/java/com/econo/tcono/domain/like/repository/LikeRepository.java
+++ b/be/tcono/src/main/java/com/econo/tcono/domain/like/repository/LikeRepository.java
@@ -1,0 +1,10 @@
+package com.econo.tcono.domain.like.repository;
+
+import com.econo.tcono.domain.like.domain.Like;
+import org.springframework.data.repository.Repository;
+
+public interface LikeRepository extends Repository<Like, Long>, LikeCustomRepository {
+    Like save(Like like);
+
+    boolean existsByPostIdAndIdpId(Long postId, Long idpId);
+}

--- a/be/tcono/src/main/java/com/econo/tcono/domain/like/repository/LikeRepository.java
+++ b/be/tcono/src/main/java/com/econo/tcono/domain/like/repository/LikeRepository.java
@@ -7,6 +7,4 @@ public interface LikeRepository extends Repository<Like, Long>, LikeCustomReposi
     Like save(Like like);
 
     boolean existsByPostIdAndIdpId(Long postId, Long idpId);
-
-    void deleteAllByPostId(Long postId);
 }

--- a/be/tcono/src/main/java/com/econo/tcono/domain/like/repository/LikeRepository.java
+++ b/be/tcono/src/main/java/com/econo/tcono/domain/like/repository/LikeRepository.java
@@ -7,4 +7,6 @@ public interface LikeRepository extends Repository<Like, Long>, LikeCustomReposi
     Like save(Like like);
 
     boolean existsByPostIdAndIdpId(Long postId, Long idpId);
+
+    void deleteAllByPostId(Long postId);
 }

--- a/be/tcono/src/main/java/com/econo/tcono/domain/like/repository/LikeRepositoryImpl.java
+++ b/be/tcono/src/main/java/com/econo/tcono/domain/like/repository/LikeRepositoryImpl.java
@@ -20,4 +20,11 @@ public class LikeRepositoryImpl implements LikeCustomRepository{
                         .and(like.idpId.eq(idpId)))
                 .execute();
     }
+
+    @Override
+    public void deleteAllByPostId(Long postId) {
+        jpaQueryFactory.delete(like)
+                .where(like.postId.eq(postId))
+                .execute();
+    }
 }

--- a/be/tcono/src/main/java/com/econo/tcono/domain/like/repository/LikeRepositoryImpl.java
+++ b/be/tcono/src/main/java/com/econo/tcono/domain/like/repository/LikeRepositoryImpl.java
@@ -1,9 +1,11 @@
 package com.econo.tcono.domain.like.repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.stereotype.Service;
 
 import static com.econo.tcono.domain.like.domain.QLike.like;
 
+@Service
 public class LikeRepositoryImpl implements LikeCustomRepository{
     private final JPAQueryFactory jpaQueryFactory;
 

--- a/be/tcono/src/main/java/com/econo/tcono/domain/like/repository/LikeRepositoryImpl.java
+++ b/be/tcono/src/main/java/com/econo/tcono/domain/like/repository/LikeRepositoryImpl.java
@@ -1,0 +1,21 @@
+package com.econo.tcono.domain.like.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import static com.econo.tcono.domain.like.domain.QLike.like;
+
+public class LikeRepositoryImpl implements LikeCustomRepository{
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public LikeRepositoryImpl(JPAQueryFactory jpaQueryFactory) {
+        this.jpaQueryFactory = jpaQueryFactory;
+    }
+
+    @Override
+    public void deleteByPostIdAndIdpId(Long postId, Long idpId) {
+        jpaQueryFactory.delete(like)
+                .where(like.postId.eq(postId)
+                        .and(like.idpId.eq(idpId)))
+                .execute();
+    }
+}

--- a/be/tcono/src/main/java/com/econo/tcono/service/like/LikeMapper.java
+++ b/be/tcono/src/main/java/com/econo/tcono/service/like/LikeMapper.java
@@ -1,0 +1,14 @@
+package com.econo.tcono.service.like;
+
+import com.econo.tcono.domain.like.domain.Like;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LikeMapper {
+    public Like mapFrom(Long postId, Long idpId) {
+        return Like.builder()
+                .postId(postId)
+                .idpId(idpId)
+                .build();
+    }
+}

--- a/be/tcono/src/main/java/com/econo/tcono/service/like/LikeService.java
+++ b/be/tcono/src/main/java/com/econo/tcono/service/like/LikeService.java
@@ -1,7 +1,7 @@
 package com.econo.tcono.service.like;
 
 public interface LikeService {
-    void flipLike(Long postId, Long idpId);
+    boolean flipLike(Long postId, Long idpId);
 
     void deleteByPostId(Long postId);
 

--- a/be/tcono/src/main/java/com/econo/tcono/service/like/LikeService.java
+++ b/be/tcono/src/main/java/com/econo/tcono/service/like/LikeService.java
@@ -1,0 +1,8 @@
+package com.econo.tcono.service.like;
+
+public interface LikeService {
+    void flipLike(Long postId, Long idpId);
+
+    void deleteByPostId(Long postId);
+
+}

--- a/be/tcono/src/main/java/com/econo/tcono/service/like/LikeServiceImpl.java
+++ b/be/tcono/src/main/java/com/econo/tcono/service/like/LikeServiceImpl.java
@@ -1,0 +1,41 @@
+package com.econo.tcono.service.like;
+
+import com.econo.tcono.domain.like.domain.Like;
+import com.econo.tcono.domain.like.repository.LikeRepository;
+import com.econo.tcono.domain.post.repository.PostRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Transactional(readOnly = true)
+public class LikeServiceImpl implements LikeService {
+    private final LikeMapper likeMapper;
+    private final LikeRepository likeRepository;
+    private final PostRepository postRepository;
+
+    public LikeServiceImpl(LikeMapper likeMapper, LikeRepository likeRepository, PostRepository postRepository) {
+        this.likeMapper = likeMapper;
+        this.likeRepository = likeRepository;
+        this.postRepository = postRepository;
+    }
+
+    @Override
+    public void flipLike(Long postId, Long idpId) {
+        boolean isExist = likeRepository.existsByPostIdAndIdpId(postId, idpId);
+        if (isExist) {
+            likeRepository.deleteByPostIdAndIdpId(postId, idpId);
+            postRepository.decreaseLikeCount(postId);
+        }
+        addNewPostLike(postId, idpId);
+        postRepository.increaseLikeCount(postId);
+    }
+
+    private void addNewPostLike(Long postId, Long idpId) {
+        Like like = likeMapper.mapFrom(postId, idpId);
+        likeRepository.save(like);
+    }
+
+    @Override
+    public void deleteByPostId(Long postId) {
+
+    }
+}

--- a/be/tcono/src/main/java/com/econo/tcono/service/like/LikeServiceImpl.java
+++ b/be/tcono/src/main/java/com/econo/tcono/service/like/LikeServiceImpl.java
@@ -36,6 +36,6 @@ public class LikeServiceImpl implements LikeService {
 
     @Override
     public void deleteByPostId(Long postId) {
-
+        likeRepository.deleteAllByPostId(postId);
     }
 }

--- a/be/tcono/src/main/java/com/econo/tcono/service/like/LikeServiceImpl.java
+++ b/be/tcono/src/main/java/com/econo/tcono/service/like/LikeServiceImpl.java
@@ -19,14 +19,16 @@ public class LikeServiceImpl implements LikeService {
     }
 
     @Override
-    public void flipLike(Long postId, Long idpId) {
+    public boolean flipLike(Long postId, Long idpId) {
         boolean isExist = likeRepository.existsByPostIdAndIdpId(postId, idpId);
         if (isExist) {
             likeRepository.deleteByPostIdAndIdpId(postId, idpId);
             postRepository.decreaseLikeCount(postId);
+            return false;
         }
         addNewPostLike(postId, idpId);
         postRepository.increaseLikeCount(postId);
+        return true;
     }
 
     private void addNewPostLike(Long postId, Long idpId) {

--- a/be/tcono/src/test/java/com/econo/tcono/domain/like/repository/LikeRepositoryTest.java
+++ b/be/tcono/src/test/java/com/econo/tcono/domain/like/repository/LikeRepositoryTest.java
@@ -1,0 +1,65 @@
+package com.econo.tcono.domain.like.repository;
+
+import com.econo.tcono.domain.like.domain.Like;
+import com.econo.tcono.global.config.QueryDslConfig;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import static org.assertj.core.api.Assertions.*;
+
+
+@DataJpaTest
+@Import(QueryDslConfig.class)
+class LikeRepositoryTest {
+    Like like1;
+
+    @Autowired
+    LikeRepository likeRepository;
+
+    @BeforeEach
+    void init() {
+        like1 = Like.builder()
+                .postId(1L)
+                .idpId(2L)
+                .build();
+    }
+
+    @Test
+    void save_테스트() {
+        Like save = likeRepository.save(like1);
+
+        assertThat(save).isEqualTo(like1);
+    }
+
+    @Test
+    void 좋아요_존재_체크_테스트() {
+        Like save = likeRepository.save(like1);
+
+        boolean b = likeRepository.existsByPostIdAndIdpId(1L, 2L);
+
+        assertThat(b).isEqualTo(true);
+
+    }
+
+    @Test
+    void 좋아요_존재_안함_체크_테스트() {
+        likeRepository.save(like1);
+
+        boolean isExist = likeRepository.existsByPostIdAndIdpId(2L, 1L);
+
+        assertThat(isExist).isEqualTo(false);
+    }
+
+    @Test
+    void delete_테스트() {
+        likeRepository.save(like1);
+        likeRepository.deleteByPostIdAndIdpId(1L, 2L);
+
+        boolean exists = likeRepository.existsByPostIdAndIdpId(1L, 2L);
+        assertThat(exists).isEqualTo(false);
+    }
+}

--- a/be/tcono/src/test/java/com/econo/tcono/domain/like/repository/LikeRepositoryTest.java
+++ b/be/tcono/src/test/java/com/econo/tcono/domain/like/repository/LikeRepositoryTest.java
@@ -62,4 +62,22 @@ class LikeRepositoryTest {
         boolean exists = likeRepository.existsByPostIdAndIdpId(1L, 2L);
         assertThat(exists).isEqualTo(false);
     }
+
+    @Test
+    void 글에_존재하는_좋아요_모두_삭제(){
+        Like like2 = Like.builder()
+                .postId(1L)
+                .idpId(3L)
+                .build();
+
+        Like like3 = Like.builder()
+                .postId(1L)
+                .idpId(4L)
+                .build();
+
+        likeRepository.save(like2);
+        likeRepository.save(like3);
+
+        likeRepository.deleteAllByPostId(1L);
+    }
 }

--- a/be/tcono/src/test/java/com/econo/tcono/domain/like/repository/LikeRepositoryTest.java
+++ b/be/tcono/src/test/java/com/econo/tcono/domain/like/repository/LikeRepositoryTest.java
@@ -77,7 +77,13 @@ class LikeRepositoryTest {
 
         likeRepository.save(like2);
         likeRepository.save(like3);
-
         likeRepository.deleteAllByPostId(1L);
+
+        boolean b2 = likeRepository.existsByPostIdAndIdpId(1L, 3L);
+        assertThat(b2).isEqualTo(false);
+
+        boolean b3 = likeRepository.existsByPostIdAndIdpId(1L, 4L);
+        assertThat(b3).isEqualTo(false);
+
     }
 }

--- a/be/tcono/src/test/java/com/econo/tcono/service/like/LikeServiceImplTest.java
+++ b/be/tcono/src/test/java/com/econo/tcono/service/like/LikeServiceImplTest.java
@@ -1,0 +1,49 @@
+package com.econo.tcono.service.like;
+
+import com.econo.tcono.domain.like.domain.Like;
+import com.econo.tcono.domain.like.repository.LikeRepository;
+import com.econo.tcono.domain.post.repository.PostRepository;
+import com.econo.tcono.global.config.QueryDslConfig;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@Import(QueryDslConfig.class)
+class LikeServiceImplTest {
+    @Mock
+    LikeRepository likeRepository;
+    @InjectMocks
+    LikeServiceImpl likeService;
+    @Mock
+    LikeMapper likeMapper;
+    @Mock
+    PostRepository postRepository;
+
+    @Test
+    void 좋아요_존재하지_않기에_생성_테스트() {
+        Like like = new Like(1L, 2L);
+        when(likeMapper.mapFrom(1L,2L)).thenReturn(like);
+        when(likeRepository.existsByPostIdAndIdpId(1L, 2L)).thenReturn(false);
+        when(likeRepository.save(like)).thenReturn(like);
+
+
+        boolean b = likeService.flipLike(1L, 2L);
+        assertThat(b).isEqualTo(true);
+    }
+
+    @Test
+    void 좋아요_존재할때_삭제_테스트() {
+        when(likeRepository.existsByPostIdAndIdpId(1L, 2L)).thenReturn(true);
+
+        boolean b = likeService.flipLike(1L, 2L);
+        assertThat(b).isEqualTo(false);
+    }
+}


### PR DESCRIPTION
<!--Close #issue_number를 작성한다.-->
close #7  
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치


## 요구사항
좋아요 기능 구현했습니다 #7 
<img width="1228" alt="image" src="https://user-images.githubusercontent.com/88534959/220825668-23c90738-a612-47e4-a888-a842eeb27c58.png">
기존 JPA에서 제공하는 exists를 사용했을 때 select하여 postId에 해당하는 likeId를 찾고, 이후 likeId로 like를 삭제합니다.

그래서 쿼리 수를 줄이고자, LikeCustomRepository를 만들어서 postId에 맞는 like를 바로 삭제하였습니다.
<img width="407" alt="image" src="https://user-images.githubusercontent.com/88534959/220826102-4a2ed246-e2db-488f-a5a7-f122c760bf4f.png">


## 변경사항


## [Optional] 논의하고 싶은 내용
